### PR TITLE
NanoHTTPD class no longer needs to be abstract

### DIFF
--- a/core/src/main/java/org/nanohttpd/protocols/http/NanoHTTPD.java
+++ b/core/src/main/java/org/nanohttpd/protocols/http/NanoHTTPD.java
@@ -122,7 +122,7 @@ import org.nanohttpd.util.IHandler;
  * See the separate "LICENSE.md" file for the distribution license (Modified BSD
  * licence)
  */
-public abstract class NanoHTTPD {
+public class NanoHTTPD {
 
     public static final String CONTENT_DISPOSITION_REGEX = "([ |\t]*Content-Disposition[ |\t]*:)(.*)";
 


### PR DESCRIPTION
As there is no longer any need to override the handle method (because a pluggable IHandler instance can be used instead) there is no need for NanoHTTPD to be abstract any more.